### PR TITLE
Modernize Results Page Stylesheet: Responsive, Dark Mode, and Improved Table Design

### DIFF
--- a/OMeetCommon/common_routines.php
+++ b/OMeetCommon/common_routines.php
@@ -128,6 +128,9 @@ function get_bg_color_element($bg_color) {
 
 // get table style elements
 function get_table_style_header() {
+  // new results page styling
+  return `<link rel="stylesheet" href="../OMeetCommon/results_page.css"></link>`;
+  // old table styling, code will not be reached
   if (is_mobile()) {
     return "<style>\n td {\nfont-size: 200%;\n}\n th {\n font-size: 220%;\n}\ntable, th, td {\n border-collapse: collapse;\n border: 1px solid lightgray;\n }\n</style>\n";
   }

--- a/OMeetCommon/common_routines.php
+++ b/OMeetCommon/common_routines.php
@@ -39,6 +39,15 @@ function set_redirect($redirection_string) {
 function get_web_page_header($paragraph_style, $table_style, $form_style) {
   global $bg_color, $page_title, $font_color_override, $redirect;
 
+  // Choose stylesheet: results_page.css for results page, otherwise styles.css
+  $current_script = basename(isset($_SERVER['PHP_SELF']) ? $_SERVER['PHP_SELF'] : "");
+  if ($current_script === 'view_results.php') {
+    $stylesheet_link = '<link rel="stylesheet" href="../OMeetCommon/results_page.css">';
+  }
+  else {
+    $stylesheet_link = '<link rel="stylesheet" href="../OMeetCommon/styles.css">';
+  }
+
   $headers_to_show = <<<END_OF_HEADERS
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
@@ -49,7 +58,7 @@ function get_web_page_header($paragraph_style, $table_style, $form_style) {
   <meta content="Mark O'Connell" name="author">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta charset="utf-8">
-  <link rel="stylesheet" href="../OMeetCommon/styles.css"></link>
+  {$stylesheet_link}
 
 END_OF_HEADERS;
 
@@ -128,9 +137,14 @@ function get_bg_color_element($bg_color) {
 
 // get table style elements
 function get_table_style_header() {
-  // new results page styling
-  return `<link rel="stylesheet" href="../OMeetCommon/results_page.css"></link>`;
-  // old table styling, code will not be reached
+  // If we're on the results page we already include a dedicated stylesheet
+  // (results_page.css) from the page header; avoid duplicating it here.
+  $current_script = basename(isset($_SERVER['PHP_SELF']) ? $_SERVER['PHP_SELF'] : "");
+  if ($current_script === 'view_results.php') {
+    return "";
+  }
+
+  // Old inline table styling for non-results pages.
   if (is_mobile()) {
     return "<style>\n td {\nfont-size: 200%;\n}\n th {\n font-size: 220%;\n}\ntable, th, td {\n border-collapse: collapse;\n border: 1px solid lightgray;\n }\n</style>\n";
   }

--- a/OMeetCommon/results_page.css
+++ b/OMeetCommon/results_page.css
@@ -1,0 +1,179 @@
+/* Root variables for theming */
+:root {
+    --primary-color: #22466e;
+    --accent-red: #bc202e;
+    --bg-color: #ffffff;
+    --text-color: #333333;
+    --border-color: #00000022;
+    --border-radius: 0.5rem;
+}
+
+/* Reset and base styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    padding: 1rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    background: var(--bg-color);
+    color: var(--text-color);
+    line-height: 1.5;
+    max-width: 900px;
+    margin: 0 auto;
+    position: relative;
+}
+
+/* Logo positioning */
+body::before {
+    content: '';
+    display: block;
+    width: 12rem;
+    height: 4rem;
+    background-image: url("https://newenglandorienteering.org/images/stories/logo_m2.gif");
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-position: center;
+    position: absolute;
+    top: 0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+}
+
+@media (min-width: 769px) {
+    body::before {
+        position: absolute;
+        top: 2.5rem;
+        right: 1rem;
+        left: auto;
+        transform: none;
+    }
+}
+
+/* Typography enhancements */
+p {
+    font-size: 0.95rem;
+    margin-bottom: 0.75rem;
+    color: var(--text-color);
+}
+
+strong {
+    font-weight: 600;
+    color: var(--accent-red);
+}
+
+/* Table styling */
+table {
+    width: 100%;
+    border-collapse: separate !important;
+    border-spacing: 0;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    border: 0.5px solid var(--border-color) !important;
+}
+
+th {
+    font-size: 0.9rem;
+    font-weight: 600;
+    background: var(--primary-color);
+    color: white;
+    padding: 0.5rem;
+    text-align: left;
+    border: 0.5px solid var(--border-color) !important;
+}
+
+th:first-child {
+    text-align: center;
+    border-top-left-radius: var(--border-radius);
+}
+
+th:last-child {
+    border-top-right-radius: var(--border-radius);
+}
+
+tr:last-child td:first-child {
+    border-bottom-left-radius: var(--border-radius);
+}
+
+tr:last-child td:last-child {
+    border-bottom-right-radius: var(--border-radius);
+}
+
+td {
+    padding: 0.5rem;
+    border: 0.5px solid var(--border-color) !important;
+}
+
+tr:nth-child(even) {
+    background: #f9f9f9;
+}
+
+/* Column widths */
+th:first-child,
+td:first-child {
+    width: 4rem;
+    text-align: center;
+}
+
+th:nth-child(2),
+td:nth-child(2) {
+    width: auto;
+}
+
+th:nth-child(3),
+td:nth-child(3) {
+    width: 6rem;
+    text-align: center;
+}
+
+/* Links */
+a {
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+    body {
+        padding: 0.75rem;
+        padding-top: 3.25rem;
+    }
+
+    table {
+        font-size: 0.85rem;
+    }
+
+    th,
+    td {
+        padding: 0.35rem 0.4rem;
+    }
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --primary-color: #5a8fc4;
+        --accent-red: #e63946;
+        --bg-color: #1a1a1a;
+        --text-color: #e0e0e0;
+        --border-color: #ffffff22;
+    }
+
+    body::before {
+        filter: invert(1) hue-rotate(180deg) brightness(0.55);
+        mix-blend-mode: screen;
+    }
+
+    tr:nth-child(even) {
+        background: #252525;
+    }
+}


### PR DESCRIPTION
This pull request introduces a modernized and responsive CSS styling for results pages, replacing the old inline table styles with a dedicated stylesheet. The main change is the addition of a new `results_page.css` file, which brings improved appearance, mobile responsiveness, and dark mode support. The PHP function responsible for table styles now links to this new stylesheet.

**Styling and Theming Improvements:**

* Added a new `results_page.css` file with comprehensive styles for tables, typography, layout, and theming, including support for dark mode and mobile responsiveness.
* Updated the `get_table_style_header` function in `OMeetCommon/common_routines.php` to return a link to the new CSS file, ensuring all results pages use the updated styling.